### PR TITLE
fix rados bench ouput parsing

### DIFF
--- a/plugins/ceph_latency_plugin.py
+++ b/plugins/ceph_latency_plugin.py
@@ -63,7 +63,7 @@ class CephLatencyPlugin(base.Base):
         if output is None:
             collectd.error('ceph-latency: failed to run rados bench :: output was None')
 
-        regex_match = re.compile('^([a-zA-Z]+) [lL]atency: \s* (\w+.?\w+)\s*', re.MULTILINE)
+        regex_match = re.compile('^([a-zA-Z]+) [lL]atency\S+: \s* (\w+.?\w+)\s*', re.MULTILINE)
         results = regex_match.findall(output)
 
         if len(results) == 0:


### PR DESCRIPTION
Hi,

Thanks for your great work ! I found a bug with ceph version 10.2.3

It seems the output of rados bench command changed :
Average Latency**(s)** :     0.00785533
Stddev Latency**(s)** :      0.0268033
Max latency**(s)** :         0.415001
Min latency**(s)** :         0.00192187

Here is the modified regex !