### PR TITLE
Fix rados bench command parsing for previous ceph versions

### DIFF
--- a/plugins/ceph_latency_plugin.py
+++ b/plugins/ceph_latency_plugin.py
@@ -63,7 +63,7 @@ class CephLatencyPlugin(base.Base):
         if output is None:
             collectd.error('ceph-latency: failed to run rados bench :: output was None')
 
-        regex_match = re.compile('^([a-zA-Z]+) [lL]atency\S+: \s* (\w+.?\w+)\s*', re.MULTILINE)
+        regex_match = re.compile('^([a-zA-Z]+) [lL]atency\S*: \s* (\w+.?\w+)\s*', re.MULTILINE)
         results = regex_match.findall(output)
 
         if len(results) == 0:


### PR DESCRIPTION
This should work with ceph version < Jewel

fixing issue #11 