### PR TITLE
Added lookup for a specific pool max avail bytes

### DIFF
--- a/plugins/ceph_pool_plugin.py
+++ b/plugins/ceph_pool_plugin.py
@@ -71,7 +71,7 @@ class CephPoolPlugin(base.Base):
         # push df results
         for pool in json_df_data['pools']:
             pool_data = data[ceph_cluster]["pool-%s" % pool['name']]
-            for stat in ('bytes_used', 'kb_used', 'objects'):
+            for stat in ('bytes_used', 'kb_used', 'objects','max_avail'):
                 pool_data[stat] = pool['stats'][stat] if pool['stats'].has_key(stat) else 0
 
         # push totals from df


### PR DESCRIPTION
Overall cluster total_avail_bytes can be different than specific pool max avail bytes, since specific pool can have for example small amount of very fast osd:s and the capacity then is a fraction of overall capacity. This works at least on ceph hammer 0.49.9